### PR TITLE
Change: make build more flexible

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -15,7 +15,4 @@ jobs:
           registry: ghcr.io
           username: ${{ secrets.GREENBONE_BOT }}
           password: ${{ secrets.GREENBONE_BOT_TOKEN }}
-      - run: cd slsw && DOCKER_BUILDKIT=1 docker build --label org.opencontainers.image.vendor=Greenbone --label org.opencontainers.image.source="https://github.com/${{ github.repository }}" -t ghcr.io/${{ github.repository }}-simulate-website .
-      - run: docker push ghcr.io/${{ github.repository }}-simulate-website
-      - run: cd slackware && DOCKER_BUILDKIT=1 docker build --label org.opencontainers.image.vendor=Greenbone --label org.opencontainers.image.source="https://github.com/${{ github.repository }}" -t ghcr.io/${{ github.repository }}-slackware .
-      - run: docker push ghcr.io/${{ github.repository }}-slackware
+      - run: make push

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 
-openvas-persistent-volumes-deployment-local.yaml
+*-local.yaml

--- a/slackware/Makefile
+++ b/slackware/Makefile
@@ -1,4 +1,12 @@
-IMAGE_NAME := greenbone/scanner-lab-slackware
+ifndef GITHUB_REPOSITORY_OWNER
+	GITHUB_REPOSITORY_OWNER := greenbone
+endif
+
+ifndef SL_C_REGISTRY
+	SL_C_REGISTRY := ghcr.io/${GITHUB_REPOSITORY_OWNER}
+endif
+
+IMAGE_NAME := ${SL_C_REGISTRY}/scanner-lab-slackware
 IMAGE_TAG := latest
 BUILD_IMAGE := DOCKER_BUILDKIT=1 docker build --build-arg VERSION=${IMAGE_TAG}
 TMP_EXPORT_PATH := /tmp/$(subst /,_,${IMAGE_NAME})_${IMAGE_TAG}.tar
@@ -14,6 +22,9 @@ gather-packages:
 
 build:
 	${BUILD_IMAGE} -f Dockerfile -t ${IMAGE_NAME}:${IMAGE_TAG} .
+
+push: build
+	docker push ${IMAGE_NAME}:${IMAGE_TAG}
 
 import-into-k3s: build
 	docker save --output ${TMP_EXPORT_PATH} ${IMAGE_NAME}:${IMAGE_TAG}

--- a/slackware/README.md
+++ b/slackware/README.md
@@ -9,7 +9,11 @@ To get all installed packages so that you can create your own product definition
 make gather-packagelist
 ```
 
-this does create a `packages.lst` file containing all installed packages within the slackware image.
+This does create a `packages.lst` file containing all installed packages within the slackware image.
+
+The private ssh host keys are stored within the repository itself to prevent each image iteration to have a different key; since the image itself is public there are already possibility to gain them.
+
+They are stored in the format `${IMAGE_TAG}_${ALGORI}_key(.pub)?`
 
 
 ## How to build
@@ -35,3 +39,9 @@ make import-into-k3s
 to build and import a new image of slackware into k3s.
 
 
+## How to generate keys
+
+
+```
+make generate-host-ssh-keys
+```

--- a/slsw/Dockerfile
+++ b/slsw/Dockerfile
@@ -1,7 +1,7 @@
 FROM golang AS lwe
 COPY . /usr/local/src
 WORKDIR /usr/local/src
-RUN make build
+RUN make build-slsw
 
 FROM alpine
 COPY --from=lwe /usr/local/src/bin/simuate-single-website /usr/local/bin/

--- a/slsw/Makefile
+++ b/slsw/Makefile
@@ -1,4 +1,29 @@
+ifndef GITHUB_REPOSITORY_OWNER
+	GITHUB_REPOSITORY_OWNER := greenbone
+endif
+
+ifndef SL_C_REGISTRY
+	SL_C_REGISTRY := ghcr.io/${GITHUB_REPOSITORY_OWNER}
+endif
+
+IMAGE_NAME := ${SL_C_REGISTRY}/scanner-lab-simulate-website
+IMAGE_TAG := latest
+BUILD_IMAGE := DOCKER_BUILDKIT=1 docker build --build-arg VERSION=${IMAGE_TAG}
+TMP_EXPORT_PATH := /tmp/$(subst /,_,${IMAGE_NAME})_${IMAGE_TAG}.tar
+
 GO_BUILD := CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o
-build:
+
+build-slsw:
 	mkdir -p bin
 	 ${GO_BUILD} bin/simuate-single-website cmd/slsw/main.go
+
+build: build-slsw
+	${BUILD_IMAGE} -f Dockerfile -t ${IMAGE_NAME}:${IMAGE_TAG} .
+
+push: build
+	docker push ${IMAGE_NAME}:${IMAGE_TAG}
+
+import-into-k3s: build
+	docker save --output ${TMP_EXPORT_PATH} ${IMAGE_NAME}:${IMAGE_TAG}
+	sudo k3s ctr images import ${TMP_EXPORT_PATH}
+	rm ${TMP_EXPORT_PATH}


### PR DESCRIPTION
In order to fork a scanner-lab repository and use custom images it is
possible to override the ghcr.io address by setting
`GITHUB_REPOSITORY_OWNER` environment variable and to use a different
registry altogether set the `SL_C_REGISTRY` environment variable.

To setup the workflow you need to set the `GREENBONE_BOT` secret in your
repository to your username and create a token and store it as
`GREENBONE_BOT_TOKEN`. The container.yml definition will then pick up
the secrets so that the images are stored as a repository package.