### PR TITLE
Add: notus advisories and products for container image

### DIFF
--- a/slackware/.gitignore
+++ b/slackware/.gitignore
@@ -1,0 +1,3 @@
+version.txt
+packages.lst
+products/

--- a/slackware/Dockerfile
+++ b/slackware/Dockerfile
@@ -6,6 +6,9 @@ RUN slackpkg update \
     openssh \
     samba \
     gnutls \
+    guile \
+    gc \
+    make \
     bind \
   && rm -rf /var/lib/slackpkg/*
 
@@ -14,6 +17,12 @@ RUN echo "gvm:gvm" | chpasswd
 RUN mkdir /home/gvm
 RUN chown gvm /home/gvm
 
+RUN mkdir -p /usr/local/src/notus/advisories
+COPY Makefile /usr/local/src/notus/
+COPY ./create_products.sh /usr/local/src/notus/
+COPY ./advisories/* /usr/local/src/notus/advisories
+WORKDIR /usr/local/src/notus
+RUN make create-products
 COPY --chmod=600 ${VERSION}_rsa_key /etc/ssh/ssh_host_rsa_key
 COPY --chmod=644 ${VERSION}_rsa_key.pub /etc/ssh/ssh_host_rsa_key.pub
 COPY --chmod=600 ${VERSION}_dsa_key /etc/ssh/ssh_host_dsa_key

--- a/slackware/Makefile
+++ b/slackware/Makefile
@@ -10,6 +10,16 @@ IMAGE_NAME := ${SL_C_REGISTRY}/scanner-lab-slackware
 IMAGE_TAG := latest
 BUILD_IMAGE := DOCKER_BUILDKIT=1 docker build --build-arg VERSION=${IMAGE_TAG}
 TMP_EXPORT_PATH := /tmp/$(subst /,_,${IMAGE_NAME})_${IMAGE_TAG}.tar
+SW_PACKAGES_DIR := /var/log/packages/
+SW_PACKAGES_CMD := ls ${SW_PACKAGES_DIR} | sort
+
+define run_product_version = 
+$(shell cat version.txt)
+endef
+
+define run_version =
+$(subst Slackware ,,$(call run_product_version))
+endef
 
 generate-host-ssh-keys:
 	ssh-keygen -t rsa -f ${IMAGE_TAG}_rsa_key -N ""
@@ -17,8 +27,15 @@ generate-host-ssh-keys:
 	ssh-keygen -t dsa -f ${IMAGE_TAG}_dsa_key -N ""
 	ssh-keygen -t ed25519 -f ${IMAGE_TAG}_ed25519_key -N ""
 
-gather-packages:
-	docker run --rm ${IMAGE_NAME}:${IMAGE_TAG} sh -c 'ls /var/log/packages/ | sort' > packages.lst
+packages.lst:
+	[ ! -e ${SW_PACKAGES_DIR} ] && docker run --rm ${IMAGE_NAME}:${IMAGE_TAG} sh -c '${SW_PACKAGES_CMD}' > packages.lst || ${SW_PACKAGES_CMD} > packages.lst
+
+version.txt:
+	[ ! -e /etc/slackware-version ] && docker run --rm ${IMAGE_NAME}:${IMAGE_TAG} sh -c 'cat /etc/slackware-version' > version.txt || cp /etc/slackware-version version.txt
+
+create-products: version.txt packages.lst
+	mkdir products || true
+	sh create_products.sh > products/slackware_$(call run_version).notus
 
 build:
 	${BUILD_IMAGE} -f Dockerfile -t ${IMAGE_NAME}:${IMAGE_TAG} .

--- a/slackware/advisories/slackware.notus
+++ b/slackware/advisories/slackware.notus
@@ -1,0 +1,27 @@
+{
+    "version": "1.0",
+    "family": "Slackware Local Security Checks",
+    "advisories": [
+        {
+            "oid": "0.0.0.0.0.0.0.0.0.0.0.1.01",
+            "title": "Slackware: Security Advisory (SSA:2003-141-01)",
+            "creation_date": TBS,
+            "last_modification": TBS,
+            "advisory_id": "SSA:FAKE",
+            "advisory_xref": "",
+            "cves": [],
+            "summary": "A fake advisory for testing purposes only.",
+            "insight": "This advisory is used to verify Notus functionality.",
+            "affected": "Each package but aaa_base installed on the container image",
+            "impact": null,
+            "xrefs": [],
+            "qod_type": "package",
+            "severity": {
+                "origin": "Greenbone",
+                "date": TBS,
+                "cvss_v2": "AV:N/AC:L/Au:N/C:P/I:N/A:N",
+                "cvss_v3": null
+            }
+        }
+    ]
+}

--- a/slackware/create_products.sh
+++ b/slackware/create_products.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+PRODUCT_NAME=$(cat version.txt)
+OID=$(grep oid advisories/slackware.notus | sed 's/.*"\(\([0-9]\+\.\)\+\)\([0-9]\+\).*/\1\3/')
+LST=$(cat packages.lst)
+printf '{ "version": "1.0", "package_type": "slack", "product_name": "'
+printf "$PRODUCT_NAME"
+printf '", "advisories": [ { "oid": "'
+printf "$OID"
+printf '", "fixed_packages": ['
+for pkg in $LST; do
+  printf '{ "name": null, "full_version": null, "full_name": "'
+  printf "$pkg"
+  printf '", "specifier": ">"},'
+done
+printf '{ "name": null, "full_version": null, "full_name": null, "specifier": ">="}'
+printf ']}]}\n'


### PR DESCRIPTION
To use the notus data within this image you need to copy
`/usr/local/src/notus/advisories`
`/usr/local/src/notus/products`

to `/var/lib/notus/`.

The products definition declare each installed package as vulnerable.
